### PR TITLE
Markup and styling changes for example code

### DIFF
--- a/src/site/api/view/webring/webring.pug
+++ b/src/site/api/view/webring/webring.pug
@@ -31,15 +31,11 @@ div.content-block
 			| to point to the wrong site.
 			| Sites currently using the old markup do not need to upgrade.
 
-	textarea#example-code(rows=10)
-		| <table>
-		| 	<tr>
-		| 		<td colspan="3">This site is a member of #{webring.name}.</td>
-		| 	</tr>
-		| 	<tr>
-		| 		<td><a href="https://webri.ng/webring/#{webring.url}/random">Random Site</a></td>
-		| 	</tr>
-		| </table>
+	textarea#example-code(rows=5)
+		| <div id="webring" style="width: fit-content; border: 2px outset">
+		| 	<p style="margin: 0; padding: 0.1em; border: 2px inset">This site is a member of #{webring.name}.</p>
+		| 	<a style="margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/#{webring.url}/random">Random Site</a>
+		| </div>
 
 
 h2 Sites

--- a/src/site/api/view/webring/webring.pug
+++ b/src/site/api/view/webring/webring.pug
@@ -31,10 +31,12 @@ div.content-block
 			| to point to the wrong site.
 			| Sites currently using the old markup do not need to upgrade.
 
-	textarea#example-code(rows=5)
-		| <div id="webring" style="width: fit-content; border: 2px outset">
+	textarea#example-code(rows=6)
+		| <divstyle="width: fit-content; border: 2px outset; text-align:center">
 		| 	<p style="margin: 0; padding: 0.1em; border: 2px inset">This site is a member of #{webring.name}.</p>
-		| 	<a style="margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/#{webring.url}/random">Random Site</a>
+		| 	<div style="margin: 0; padding: 0.1em; border: 2px inset">
+		|		<a href="https://webri.ng/webring/#{webring.url}/random">Random Site</a>
+		|	</div>
 		| </div>
 
 

--- a/src/site/static/site.js
+++ b/src/site/static/site.js
@@ -178,16 +178,14 @@ function cancelDelete(webringUrl)
 function getExampleMarkup(webringName, webringUrl, referringSiteUrl)
 {
 	const exampleCodeElement = document.getElementById('example-code');
-	exampleCodeElement.value = `<table>
-	<tr>
-		<td colspan="3">This site is a member of ${webringName}.</td>
-	</tr>
-	<tr>
-		<td><a href="https://webri.ng/webring/${webringUrl}/previous?via=${referringSiteUrl}">Previous Site</a></td>
-		<td><a href="https://webri.ng/webring/${webringUrl}/random?via=${referringSiteUrl}">Random Site</a></td>
-		<td><a href="https://webri.ng/webring/${webringUrl}/next?via=${referringSiteUrl}">Next Site</a></td>
-	</tr>
-</table>`;
+	exampleCodeElement.value = `<div id="webring" style="width: fit-content; border: 2px outset">
+	<p style="margin: 0; padding: 0.1em; border: 2px inset">This site is a member of ${webringName}.</p>
+	<div id="webring-nav" style="display: flex">
+		<a style="margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/${webringUrl}/previous?via=${referringSiteUrl}">Previous Site</a>
+		<a style="margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/${webringUrl}/random?via=${referringSiteUrl}">Random Site</a>
+		<a style="margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/${webringUrl}/next?via=${referringSiteUrl}">Next Site</a>
+	</div>
+</div>`;
 }
 
 

--- a/src/site/static/site.js
+++ b/src/site/static/site.js
@@ -178,12 +178,12 @@ function cancelDelete(webringUrl)
 function getExampleMarkup(webringName, webringUrl, referringSiteUrl)
 {
 	const exampleCodeElement = document.getElementById('example-code');
-	exampleCodeElement.value = `<div id="webring" style="width: fit-content; border: 2px outset">
+	exampleCodeElement.value = `<div style="width: fit-content; border: 2px outset; text-align:center">
 	<p style="margin: 0; padding: 0.1em; border: 2px inset">This site is a member of ${webringName}.</p>
-	<div id="webring-nav" style="display: flex">
-		<a style="margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/${webringUrl}/previous?via=${referringSiteUrl}">Previous Site</a>
-		<a style="margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/${webringUrl}/random?via=${referringSiteUrl}">Random Site</a>
-		<a style="margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/${webringUrl}/next?via=${referringSiteUrl}">Next Site</a>
+	<div style="display: flex">
+		<a style="flex: 1; margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/${webringUrl}/previous?via=${referringSiteUrl}">Previous Site</a>
+		<a style="flex: 1; margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/${webringUrl}/random?via=${referringSiteUrl}">Random Site</a>
+		<a style="flex: 1; margin: 0; padding: 0.1em; border: 2px inset" href="https://webri.ng/webring/${webringUrl}/next?via=${referringSiteUrl}">Next Site</a>
 	</div>
 </div>`;
 }


### PR DESCRIPTION
Hi!

So here I've made a point to style the markup inline, so it looks like a proper 90s table.

But, you can pull all the 'style' attributes out, and it looks fine.

It might be worth going one step further and offering two boxes to copy, one for a `<style>` tag to go into the `<head>`, and then the plain markup without styles within another.

But I wanted to just do this first to start the conversation - I don't expect this to be pulled in as-is. I've made a little playground here:
https://codepen.io/sarajw/pen/BaqbQGe

Thanks for being cool with me contributing :)

Edit: Just to say I've not pulled this all locally to my machine and run it live, so I've edited code without checking it works on the site itself - so it may bring about bugs and apologies if so!